### PR TITLE
oracle_parameter: Support for Python3

### DIFF
--- a/oracle_parameter
+++ b/oracle_parameter
@@ -106,7 +106,7 @@ def check_parameter_exists(module, mode, msg, cursor, name):
             msg = error.message+ 'sql: ' + sql
             return False
 
-    if result > 0:
+    if result:
         return True
     else:
         msg = 'The parameter (%s) doesn\'t exist' % name


### PR DESCRIPTION
Fixing 'TypeError: '>' not supported between instances of 'tuple' and 'int''