### PR TITLE
fixed quotes for ALTER USER

### DIFF
--- a/oracle_user
+++ b/oracle_user
@@ -252,7 +252,7 @@ def modify_user(module, cursor, schema, schema_password, schema_password_hash, d
 				sql += ' identified by values \'%s\'' % (schema_password_hash)
 			elif schema_password and not password_matches_hash(schema_password,old_pw_hash):
 				pw_change_needed = True
-				sql += ' identified by %s ' % (schema_password)
+				sql += ' identified by \"%s\" ' % (schema_password)
 		elif authentication_type == 'external':
 			sql += ' identified externally '
 			sql_get_curr_def += ' ,lower(authentication_type)'


### PR DESCRIPTION
this PR fixes a bug, when altering a user with special characters in password. Now the password is properly quoted and will work for all password changes.